### PR TITLE
fix: updated Sysdyne version of strong-remoting to fix the issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "serve-favicon": "^2.2.0",
     "stable": "^0.1.5",
     "strong-globalize": "^2.6.2",
-    "strong-remoting": "git@github.com:istrada/strong-remoting.git#current_context",
+    "strong-remoting": "git@github.com:istrada/strong-remoting.git#istrada",
     "uid2": "0.0.3",
     "underscore.string": "^3.0.3"
   },


### PR DESCRIPTION
This updates the version of `strong-remoting` to fix the bug which made me unable to properly return node streams, which was possible with callback remote methods. This actually got fixed in `3.x` version of `strong-remoting` (https://github.com/strongloop/strong-remoting/commit/6201d1b7221764b1c3369eac1751ce698097368d) so this essentialy backports the fix to our version.