### PR TITLE
fix: fixed async remote hooks blocking HTTP responses

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -202,7 +202,7 @@ module.exports = function(registry) {
       this._runWhenAttachedToApp(function(app) {
         var remotes = app.remotes();
         remotes.before(className + '.' + name, function(ctx, next) {
-          fn(ctx, ctx.result, next);
+          return fn(ctx, ctx.result, next);
         });
       });
     };
@@ -213,7 +213,7 @@ module.exports = function(registry) {
       this._runWhenAttachedToApp(function(app) {
         var remotes = app.remotes();
         remotes.after(className + '.' + name, function(ctx, next) {
-          fn(ctx, ctx.result, next);
+          return fn(ctx, ctx.result, next);
         });
       });
     };


### PR DESCRIPTION
Lack of return in remote hook calls in `model.js` prevented async remote hooks from being usable, as they hang up the server in process. This fixes that.